### PR TITLE
Fix: add missing formState API documentation

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -821,6 +821,7 @@ function Builder({ formData, showApi }: any) {
               apiSectionsRef.current.formStateRef = ref
             }}
           >
+            <ApiFormState />
           </section>
 
           <hr />


### PR DESCRIPTION
It was [accidentally removed](https://github.com/react-hook-form/react-hook-form-website/commit/d94abba830342d0a3fba6f9da3b9625c26a4157a#diff-8e2137ec74d914a55499d50c2858f9bcL837).