### PR TITLE
Fix typo in useForm register API docs

### DIFF
--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -47,7 +47,7 @@ export default function ApiRefTable({ goToSection }) {
       <p>
         <Note>Important:</Note> <code>name</code> is <b>required</b> and{" "}
         <b>unique</b>. Input name also support dot and bracket syntax, which
-        allow you to easily create nested or fields. Example table is
+        allow you to easily create nested form fields. Example table is
         below:
       </p>
 


### PR DESCRIPTION
My understanding is that this was supposed to read, "... create nested _form_ fields".

If it is supposed to read a different way, I'm happy to update the PR.