### PR TITLE
Add `clearError` to the side menu.

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -167,6 +167,7 @@ const links = [
   "handleSubmit",
   "reset",
   "setError",
+  "clearError",
   "setValue",
   "getValues",
   "triggerValidation",
@@ -299,6 +300,10 @@ function ApiPage({ formData }: { formData?: any }) {
               setError
             </CodeAsLink>
             ,{" "}
+            <CodeAsLink onClick={() => goToSection("clearError")}>
+              clearError
+            </CodeAsLink>
+            ,{" "}
             <CodeAsLink onClick={() => goToSection("setValue")}>
               setValue
             </CodeAsLink>
@@ -330,6 +335,7 @@ function ApiPage({ formData }: { formData?: any }) {
   defaultValues: {},
   validationFields: [],
   validationSchema: {},
+  validationSchemaOption: { abortEarly: false },
   submitFocusError: true,
   nativeValidation: false,
 })`}


### PR DESCRIPTION
I was about to add description for `validateSchemaOption` but never understood its uses like I thought setting `abortEarly` to `false` would return all errors instead of one.