### PR TITLE
Minor correction to add errors to useForm initialization

### DIFF
--- a/src/components/codeExamples/typeScript.ts
+++ b/src/components/codeExamples/typeScript.ts
@@ -7,7 +7,7 @@ type FormData = {
 }
 
 export default function App() {
-  const { register, setValue, handleSubmit } = useForm<FormData>()
+  const { register, setValue, handleSubmit, errors } = useForm<FormData>()
   const onSubmit = handleSubmit(({ name, email }) => {}) // firstName and lastName will have correct type
 
   return (


### PR DESCRIPTION
The `errors` object is missing from the destructuring example in the TypeScript section.