### PR TITLE
fix typos in example codes

### DIFF
--- a/src/components/codeExamples/accessibleCodeFinal.ts
+++ b/src/components/codeExamples/accessibleCodeFinal.ts
@@ -21,7 +21,7 @@ export default function App() {
       />
       {errors.name && errors.name.type === "required" && (
         {/* the id field is used to associated with aria-describedby*/}
-        <span role="alert" id="error-field-name">
+        <span role="alert" id="error-field-required">
           This is required
         </span>
       )}

--- a/src/components/codeExamples/formWizard.ts
+++ b/src/components/codeExamples/formWizard.ts
@@ -15,7 +15,7 @@ createStore({
 export default function App() {
   return (
     <StateMachineProvider>
-      <h1>Page Form Wizzard</h1>
+      <h1>Page Form Wizard</h1>
 
       <Router>
         <Route exact path="/" component={Step1} />


### PR DESCRIPTION
I found some typos translating 'Adavanced' page

* in the accessbility example, `id` doesn't match with `aria-describedby`
* Wizzard -> Wizard