### PR TITLE
Improve i18n navigations

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -38,6 +38,7 @@ import { useStateMachine } from "little-state-machine"
 import generic from "../data/generic"
 import api from "../data/api"
 import StarRepo from "./StarRepo"
+import translateLink from "./logic/translateLink"
 
 const { useRef, useEffect } = React
 
@@ -830,7 +831,7 @@ function ApiPage({
             <p>{generic.advanceUsage[currentLanguage].description}</p>
             <PrimaryButton
               onClick={() => {
-                navigate("/advanced-usage")
+                navigate(translateLink("advanced-usage", currentLanguage))
               }}
               style={{ margin: "40px auto" }}
             >

--- a/src/components/BuilderPage.tsx
+++ b/src/components/BuilderPage.tsx
@@ -22,6 +22,7 @@ import LearnMore from "./learnMore"
 import goToBuilder from "./utils/goToBuilder"
 import builder from "../data/builder"
 import generic from "../data/generic"
+import translateLink from "./logic/translateLink"
 
 const { useState, useRef, useEffect } = React
 
@@ -484,7 +485,7 @@ function BuilderPage({
                     document.body.style.overflow = "auto"
                     HomeRef.current.scrollIntoView({ behavior: "smooth" })
                   } else {
-                    navigate("/?goToDemo&updated=true")
+                    navigate(translateLink("?goToDemo&updated=true", currentLanguage))
                   }
                 }}
               >

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -14,6 +14,7 @@ import breakpoints from "../styles/breakpoints"
 import FeaturesList from "./FeaturesList"
 import { useStateMachine } from "little-state-machine"
 import home from "../data/home"
+import translateLink from "./logic/translateLink"
 
 const { useState, useRef, useEffect } = React
 
@@ -155,14 +156,14 @@ function HomePage({
         >
           <PrimaryButton
             onClick={() => {
-              navigate("/get-started")
+              navigate(translateLink("get-started", currentLanguage))
             }}
           >
             {home.getStarted[currentLanguage]}
           </PrimaryButton>
           <PrimaryButton
             onClick={() => {
-              navigate("/api")
+              navigate(translateLink("api", currentLanguage))
             }}
           >
             API

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -8,6 +8,7 @@ import { useStateMachine } from "little-state-machine"
 import nav from "../data/nav"
 import translateLink from "./logic/translateLink"
 import { updateCurrentLanguage } from "../actions/languageActions"
+import { globalHistory, navigate } from "@reach/router"
 
 const IconGroup = styled.div`
   position: absolute;
@@ -197,6 +198,7 @@ export default function Nav({ defaultLang }: { defaultLang: string }) {
     language && language.currentLanguage
       ? language
       : { currentLanguage: defaultLang }
+  const location = globalHistory.location
 
   return (
     <>
@@ -260,7 +262,9 @@ export default function Nav({ defaultLang }: { defaultLang: string }) {
       <LangsSelect>
         <select
           onChange={e => {
-            action(e.target.value)
+            const selectedLanguage = e.target.value
+            action(selectedLanguage)
+            navigate(getNavLink(location.pathname.substr(1), selectedLanguage))
           }}
           defaultValue={currentLanguage}
         >
@@ -269,9 +273,7 @@ export default function Nav({ defaultLang }: { defaultLang: string }) {
           <option value="jp" disabled>
             日本语
           </option>
-          <option value="kr">
-            한국어
-          </option>
+          <option value="kr">한국어</option>
         </select>
       </LangsSelect>
 
@@ -340,4 +342,29 @@ export default function Nav({ defaultLang }: { defaultLang: string }) {
       </ActionButtonGroup>
     </>
   )
+}
+
+function getNavLink(path: string, selectedLanguage: string) {
+  const i18nPagePathRegex = /^([a-z]{2})(\/\S+|\?.+)/
+  const i18nHomePageRegex = /^[a-z]{2}$/
+  const i18nPageMatched = path.match(i18nPagePathRegex)
+  const isHomePage = i18nHomePageRegex.test(path)
+
+  if (selectedLanguage === "en") {
+    if (isHomePage) {
+      return '/'
+    }
+    if (i18nPageMatched != null) {
+      return i18nPageMatched[2]
+    }
+    return path
+  }
+
+  const targetPath =
+    i18nPageMatched != null
+      ? i18nPageMatched[2].substr(1)
+      : isHomePage
+      ? ''
+      : path
+  return translateLink(targetPath, selectedLanguage)
 }

--- a/src/components/learnMore.tsx
+++ b/src/components/learnMore.tsx
@@ -4,6 +4,7 @@ import { H1 } from "../styles/typography"
 import { PrimaryButton } from "../styles/buttons"
 import { CenterContent } from "../styles/containers"
 import generic from "../data/generic"
+import translateLink from "./logic/translateLink"
 
 export default function LearnMore({
   currentLanguage,
@@ -17,7 +18,7 @@ export default function LearnMore({
 
       <PrimaryButton
         onClick={() => {
-          navigate("/api")
+          navigate(translateLink("api", currentLanguage))
         }}
         style={{ margin: "40px auto" }}
       >

--- a/src/components/logic/translateLink.ts
+++ b/src/components/logic/translateLink.ts
@@ -5,5 +5,5 @@ export default (link, currentLanguage) => {
     return link
   }
 
-  return `/${currentLanguage}/${link}`
+  return `/${currentLanguage}${link ? '/' + link : ''}`
 }


### PR DESCRIPTION
1. Applied `translatedLink` to some navigations which are missing it.
2. When changing the language with the `select` component on the upper right side, it also changes the current pathname following the selected language.


The second one looks a bit dirty and might be unreadable. We can revert it anytime.