### PR TITLE
fix validation example on a main page

### DIFF
--- a/src/components/codeExamples/reactHookFormCode.ts
+++ b/src/components/codeExamples/reactHookFormCode.ts
@@ -24,7 +24,7 @@ const Example = () => {
       <input
         name="username"
         ref={register({
-          validate: value => value === "admin" || "Nice try!"
+          validate: value => !(value === "admin") || "Nice try!"
         })}
       />
       {errors.username && errors.username.message}


### PR DESCRIPTION
validation function should returns true on success and error string on failure.
here's example of original behaviour and fixed:
![image](https://user-images.githubusercontent.com/659780/69024304-bf0a1280-09f4-11ea-9e09-69f6db816fb9.png)
