### PR TITLE
Fix broken example React.memo -> React.useMemo

### DIFF
--- a/src/components/codeExamples/formContextPerformance.ts
+++ b/src/components/codeExamples/formContextPerformance.ts
@@ -24,7 +24,7 @@ function NestedInput() {
   } = useFormContext();
   
   // we can use React.memo to prevent re-render except dirty state changed
-  return React.memo(
+  return React.useMemo(
     () => (
       <div>
         <input name="test" ref={register} />


### PR DESCRIPTION
I noted an error in one of the examples provided on your Advanced Usage page, when I attempted to utilise same in my project.

I created a CodeSandbox for review if required, although it appeared to be a pretty straightforward fix (although I'm no memo/useMemo expert).

[https://codesandbox.io/s/optimistic-worker-phhks](https://codesandbox.io/s/optimistic-worker-phhks)

Cheers