### PR TITLE
fix: broken link to advanced usage

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -859,7 +859,7 @@ function ApiPage({
             <p>{generic.advanceUsage[currentLanguage].description}</p>
             <PrimaryButton
               onClick={() => {
-                navigate(translateLink("advanced-usage", currentLanguage))
+                navigate(translateLink("/advanced-usage", currentLanguage))
               }}
               style={{ margin: "40px auto" }}
             >


### PR DESCRIPTION
Needed to be absolute.

Note: this may also be an issue [on this line](https://github.com/react-hook-form/react-hook-form-website/blob/d8912d9521462d6fb2f04effb238110ae3c63e7e/src/data/es/api.tsx#L302), but I am unfamiliar with the codebase and unable to reproduce the error on that page.