### PR TITLE
Fix connect form example

### DIFF
--- a/src/components/codeExamples/connectForm.ts
+++ b/src/components/codeExamples/connectForm.ts
@@ -4,7 +4,7 @@ import { useFormContext } from 'react-hook-form';
 export const ConnectForm = ({ children }) => {
  const methods = useFormContext();
  
- return props.children({
+ return children({
    ...methods
  });
 };


### PR DESCRIPTION
Corrected `props.children` to `children` in connectForm example.
Thank you! 😸