### PR TITLE
Fix navigation error when using translated page

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -875,7 +875,7 @@ function ApiPage({
             <p>{generic.advanceUsage[currentLanguage].description}</p>
             <PrimaryButton
               onClick={() => {
-                navigate(translateLink("/advanced-usage", currentLanguage))
+                navigate(translateLink("advanced-usage", currentLanguage))
               }}
               style={{ margin: "40px auto" }}
             >


### PR DESCRIPTION
Hello.
When a user clicks the `advancedUsage` button on a translated page, 
the page doesn't show up correctly.
So I fixed a `link` parameter, from `/advanced-usage` to `advanced-usage`.