### PR TITLE
Fix Redux Form example in Library Code Comparison

### DIFF
--- a/src/components/codeExamples/reduxFormCode.ts
+++ b/src/components/codeExamples/reduxFormCode.ts
@@ -8,7 +8,7 @@ const validate = values => {
 
   if (!values.username) {
     errors.username = "Required";
-  } else if (values.username.length !== "admin") {
+  } else if (values.username !== "admin") {
     errors.username = "Nice try!";
   }
 

--- a/src/components/codeExamples/reduxFormCode.ts
+++ b/src/components/codeExamples/reduxFormCode.ts
@@ -8,7 +8,7 @@ const validate = values => {
 
   if (!values.username) {
     errors.username = "Required";
-  } else if (values.username !== "admin") {
+  } else if (values.username === "admin") {
     errors.username = "Nice try!";
   }
 


### PR DESCRIPTION
This addresses #165. I've also fixed the equality check on the same line - unless I'm misinterpreting the goal of that validation, I believe it should be `values.username === "admin"` rather than `values.username !== "admin"`, similar to the Formik example.