### PR TITLE
Fix Advanced Usage broken link

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -859,7 +859,7 @@ function ApiPage({
             <button
               className={buttonStyles.primaryButton}
               onClick={() => {
-                navigate(translateLink("advanced-usage", currentLanguage))
+                navigate(translateLink("/advanced-usage", currentLanguage))
               }}
               style={{ margin: "40px auto" }}
             >


### PR DESCRIPTION
The **Advanced Usage** button on https://react-hook-form.com/api takes to https://react-hook-form.com/api/advanced-usage which does not exist.

This PR fixes the broken link.