### PR TITLE
Fixing reset button data

### DIFF
--- a/src/components/codeExamples/controlledMixedUncontrolled.ts
+++ b/src/components/codeExamples/controlledMixedUncontrolled.ts
@@ -28,7 +28,7 @@ function App() {
       <br />
       <Input inputRef={register} name="input" />
 
-      <button type="button" onClick={() => reset({ defaultValues })}>Reset</button>
+      <button type="button" onClick={() => reset({ ...defaultValues })}>Reset</button>
       <input type="submit" />
     </form>
   );


### PR DESCRIPTION
Spreading default values to avoid material-ui error being printed on console.

> Material-UI: you have provided an out-of-range value `undefined` for the select component.
> Consider providing a value that matches one of the available options or ''.
> The available values are `10`, `20`, `30`.