### PR TITLE
fix: add missing components in import line

### DIFF
--- a/src/components/codeExamples/connectForm.ts
+++ b/src/components/codeExamples/connectForm.ts
@@ -1,5 +1,5 @@
 export default `import { useStateMachine } from 'little-state-machine';
-import { useFormContext } from 'react-hook-form';
+import { FormContext, useForm, useFormContext } from 'react-hook-form';
 
 export const ConnectForm = ({ children }) => {
  const methods = useFormContext();


### PR DESCRIPTION
I think it is good to make it explicit where those functions are coming from.