### PR TITLE
Remove state machine hook import in connect form example

### DIFF
--- a/src/components/codeExamples/connectForm.ts
+++ b/src/components/codeExamples/connectForm.ts
@@ -1,5 +1,4 @@
-export default `import { useStateMachine } from 'little-state-machine';
-import { FormContext, useForm, useFormContext } from 'react-hook-form';
+export default `import { FormContext, useForm, useFormContext } from 'react-hook-form';
 
 export const ConnectForm = ({ children }) => {
  const methods = useFormContext();


### PR DESCRIPTION
In Advanced Connect Form example, `useStateMachine` hook is not used and unnecessary.  
URL: https://react-hook-form.com/advanced-usage#ConnectForm