### PR TITLE
fix #184 expect formState.touched to be an object

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -38,18 +38,12 @@ function Form({
   methods: any
   devTool?: boolean
 }) {
-  const {
-    register,
-    errors,
-    handleSubmit,
-    watch,
-    formState: { touched },
-    reset,
-  } =
+  const { register, errors, handleSubmit, watch, formState, reset } =
     methods ||
     useForm({
       mode: "onChange",
     })
+  const touched = Object.keys(formState.touched)
   const {
     state: { formData },
   } = useStateMachine()


### PR DESCRIPTION
On my little quest to understand how the regression happened, I assumed there was an API change. Looking through the releases found [v4.1.0](https://github.com/react-hook-form/react-hook-form/releases/tag/v4.1.0) and the corresponding change react-hook-form/react-hook-form#711.

This change respects new API by making `touched` an array again how the rest of the rendering code expects.
