### PR TITLE
fix: redux form example

### DIFF
--- a/src/components/codeExamples/reduxFormCode.ts
+++ b/src/components/codeExamples/reduxFormCode.ts
@@ -42,11 +42,11 @@ const Form = props => {
   );
 };
 
-const FormRedux = reduxForm({ form: "syncValidation", validate })(Example);
+const FormRedux = reduxForm({ form: "syncValidation", validate })(Form);
 
 const Example = () => (
   <Provider store={store}>
-    <Example/>
+    <FormRedux />
   </Provider>
 );
 `


### PR DESCRIPTION
I was looking at the examples on the home page today and the end of the redux form example didn't look quite right. I'm pretty sure this is what it should be.