### PR TITLE
Controller:onChange callback have to return value instead of object

### DIFF
--- a/src/components/codeExamples/controller.ts
+++ b/src/components/codeExamples/controller.ts
@@ -23,8 +23,8 @@ function App() {
         control={control}
         rules={{ required: true }}
         onChange={([selected]) => {
-          // React Select return object instead of value for selection
-          return { value: selected };
+          // Place your logic here
+          return selected;
         }}
         name="reactSelect"
         defaultValue={{ value: 'chocolate' }}


### PR DESCRIPTION
Here (https://react-hook-form.com/api#Controller) we have an example for Controller with onChange callback.

As far as I see from release notes for V5.0.0 (https://github.com/react-hook-form/react-hook-form/releases/tag/v5.0.0) we need to return value instead of an object like `{ value: selected }`

I use react-hook-form with `https://ant.design/` and I've found it useful to update this example