### PR TITLE
Update Korean translation 200401

### DIFF
--- a/src/data/kr/advanced.tsx
+++ b/src/data/kr/advanced.tsx
@@ -413,21 +413,21 @@ export default {
     ),
   },
   customHookWithValidationResolver: {
-    title: "Custom Hook with Validation Resolver",
+    title: "Validation Resolver 를 커스텀 훅으로 정의하기",
     description: (
       <>
         <p>
-          You can build a custom hook as a validation resolver. A custom hook
-          can easily integration with yup/Joi/Superstruct as a validation
-          method, and to be used inside validation resolver.
+          유효성 검사에 쓸 리졸버(resolver)를 커스텀 훅으로 만들 수 있습니다.
+          커스텀 훅은 yup/Joi/Superstruct 같은 유효성 검사 방법과 쉽게 결합될 수
+          있으며, 이런 방법들을 유효성 검사 리졸버 내부에서 사용할 수 있습니다.
         </p>
         <ul>
           <li>
-            Define a memoized validation schema (or define it outside your
-            component if you don't have any dependencies)
+            메모이즈 된 유효성 검사 스키마(혹은 컴포펀트 바깥에 선언하여
+            의존성이 생기지 않도록)를 정의하세요
           </li>
-          <li>Use the custom hook, by passing the validation schema</li>
-          <li>Pass the validation resolver to the useForm hook</li>
+          <li>커스텀 훅을 호출하면서 유효성 검사 스키마를 전달하세요</li>
+          <li>useForm 훅에 유효성 검사 리졸버를 전달하세요</li>
         </ul>
 
         <CodeArea rawData={customHookWithValidationResolver} />
@@ -435,33 +435,32 @@ export default {
     ),
   },
   workingWithVirtualizedList: {
-    title: "Working with virtualized list",
+    title: "시각화된 리스트를 다루기",
     description: (
       <>
         <p>
-          Imagine a scenario where you have a table of data. This table might
-          contain hundreds or thousands of rows, and each row will have inputs.
-          A common practice is to only render the items that are in the
-          viewport, however this will cause issues as the items are removed from
-          the DOM when they are out of view, and re-added. This will cause items
-          to reset to their default values when they re-enter the viewport.
+          데이터 표를 다루는 시나리오를 상상해봅시다. 이 테이블은 아마
+          수백게에서 수천 개의 행을 포함하고 있고, 각각의 행은 인풋을 가지고
+          있을 것입니다. 가장 이상적인 처리 방법은 뷰포트에 나타나는 아이템만
+          랜더링하는 것이겠지만, 뷰에서 벗어난 DOM 을 아예 제거해버렸다가 다시
+          추가하는 동작이 일어날 수 있습니다. 그러면 이전 아이템이 나타나야하는
+          뷰포트로 돌아갔을 때 해당 아이템이 기본값으로 초기화될 것입니다.
         </p>
 
         <p>
-          To work around this, you can manually register the fields, and then
-          programatically set the value of the field.
+          이 문제를 해결하기 위해서 필드를 수동으로 등록한 다음 프로그램적으로
+          필드의 값을 설정해야 합니다.
         </p>
 
         <p>
-          An example is shown below using{" "}
           <a
             target="_blank"
             rel="noopener noreferrer"
             href="https://github.com/bvaughn/react-window"
           >
             react-window
-          </a>
-          .
+          </a>{" "}
+          를 사용할 때의 예제는 다음과 같습니다.
         </p>
 
         <CodeArea

--- a/src/data/kr/api.tsx
+++ b/src/data/kr/api.tsx
@@ -780,18 +780,18 @@ onChange={{([ { checked } ]) => ({ checked })}}`}
           <td></td>
           <td>
             <p>
-              This callback allows the custom hook to focus on the input when
-              there is an error. This function is applicable for both React and
-              React-Native components as long as they can be focused.
+              유효성 검사 에러가 발생했을 때 이 콜백을 이용하여 특정 인풋으로
+              포커스를 이동시킬 수 있습니다. 이 함수는 포커스만 시킬 수 있다면
+              React 및 React-Native 컴포넌트에 모두 적용됩니다.
             </p>
             <p>
-              Here is a{" "}
+              여기에{" "}
               <a
                 href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                working example with MUI
+                MUI 를 활용한 예제가 있습니다
               </a>
               .
             </p>

--- a/src/data/kr/api.tsx
+++ b/src/data/kr/api.tsx
@@ -1202,17 +1202,16 @@ React.useEffect(() => {
           반드시 인풋 값과 연결되어야 합니다.
         </p>
         <p>
-          <b className={typographyStyles.note}>참고:</b>이 함수는
+          <b className={typographyStyles.note}>참고:</b> 이 함수는
           <code>validationSchema</code>와 유사한 사용자 정의 후크 내부에
           캐시되며, <code>validationContext</code>는 다시 렌더링 할 때마다
           변경할 수있는 변경 가능한 객체입니다.
         </p>
-        // todo: Dohyung please translate
         <p>
-          <b className={typographyStyles.note}>Note:</b> re-validate input will
-          only occur one field at time during user’s interaction, because the
-          lib itself will evaluate the error object to the specific field and
-          trigger re-render accordingly.
+          <b className={typographyStyles.note}>참고:</b> 입력값을 다시 검사하는
+          것은 사용자의 행동에 따라 한 필드당 하나씩만 동작합니다. 왜냐하면
+          라이브러리 자체에서 에러 객체의 특정 필드를 대조해보고 그에 따라
+          리랜더링을 실행하기 때문입니다.
         </p>
       </>
     ),

--- a/src/data/kr/faq.tsx
+++ b/src/data/kr/faq.tsx
@@ -451,24 +451,22 @@ export default {
         </div>
       ),
     },
-    // todo: korean translation please
     {
-      title:
-        "Why is default value not changing correctly with ternary operator?",
+      title: "왜 삼항 연산자를 적용한 기본값은 의도한대로 반응하지 않나요?",
       description: (
         <>
           <p>
-            React Hook Form doesn't control your entire form and inputs, which
-            is the reason why React wouldn't recognise the actual input that has
-            been exchanged or swopped. As a solution, you can resolve this
-            problem by giving a unique <code>key</code> prop to your input. You
-            can also read more about the key props from{" "}
+            React Hook Form 은 전체 폼과 인풋을 제어하지 않습니다. 그래서
+            리액트는 실제 입력 값이 바뀌었는지 알아차리지 못하는 것입니다. 이
+            문제를 해결하기 위해 인풋 컴포넌트에 고유의 <code>key</code> prop 을
+            전달해줄 수 있습니다. <code>key</code> prop 에 대해서 더 자세히
+            알아보시려면{" "}
             <a
               target="_blank"
               rel="noopener noreferrer"
               href="https://kentcdodds.com/blog/understanding-reacts-key-prop"
             >
-              this article written by Kent C. Dodds
+              Kent C. Dodds 가 쓴 이 글을 읽어보세요
             </a>
             .
           </p>
@@ -480,31 +478,31 @@ export default {
       ),
     },
     {
-      title: "Controller not working with submitFocusError?",
+      title:
+        "submitFocusError 옵션을 주어도 Controller 한테는 동작하지 않는데요?",
       description: (
         <>
           <p>
-            After a validation error, React Hook Form will automatically focus
-            on the invalids elements of which have their proper ref, like the
-            native inputs (eg: <code>{`<input />`}</code>) or some 3rd party
-            Components that correctly export his ref (eg: from MUI{" "}
+            유효성 검사 후 에러가 발생할 때, React Hook Form 은 자동으로 잘못된
+            인풋 엘리먼트로 포커스를 맞춥니다. 그 인풋 엘리먼트는 적절하게 ref
+            가 할당되어 있어야 합니다. 예를 들어 기본 <code>{`<input />`}</code>{" "}
+            이나, 적절하게 ref 를 드러내는 서드파티 컴포넌트(예: MUI의
             <code>{`<TextField inputRef={register({required: 'Field Required'})} />`}</code>
-            )
+            )처럼 말입니다.
           </p>
 
           <p>
-            However, for some 3rd party controlled Components like{" "}
-            <code>{`<Autocomplete>`}</code> from MUI or <code>{`<XX>`}</code>{" "}
-            from AntD) it's very difficult to predict his ref because the
-            formats changes, so React Hook Form will properly detect the
-            validation error but will not be able to automatically focus that
-            kind of Components.
+            하지만 MUI의 <code>{`<Autocomplete>`}</code> 나, AntD 의{" "}
+            <code>{`<XX>`}</code> 같은 일부 서드파티 컴포넌트는 형태가 바뀌기
+            때문에 ref 를 예측하기 아주 어렵습니다. 그래서 React Hook Form 은
+            유효성을 검사하고 에러를 적절히 찾아닐 수 있지만 이런 컴포넌트에
+            바로 포커스를 맞출 수 없습니다.
           </p>
 
           <p>
-            As a workaround, after the validation error, you can manually focus
-            on the 3rd party controlled Component (if you can get the actual
-            internal input ref), for example:
+            우회 해결책으로 실제로 인풋 ref 를 가져올 수 있다면, 유효성 검사 후
+            에러가 발생할 때 수동으로 서드파티 컴포넌트의 포커스를 지정해줄 수
+            있습니다.
           </p>
           <CodeArea rawData={focusController} />
 


### PR DESCRIPTION
* New note for `validationResolver` about handling error
* New FAQ entries about the ternary operator and working `Controller` with the `submitFocusError` option.
* New API - `Controller#onFocus`
* New advanced usages
  - Custom hook with the validation resolver
  - Working with the visualized list