### PR TITLE
fix:typo from registter to register

### DIFF
--- a/src/data/kr/api.tsx
+++ b/src/data/kr/api.tsx
@@ -732,7 +732,7 @@ export default {
           </td>
           <td />
           <td>
-            <code>registter</code> 에 따른 유효성 검사 규칙.
+            <code>register</code> 에 따른 유효성 검사 규칙.
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
Noticed a small typo in the [docs](https://react-hook-form.com/kr/api#Controller).
Changed `registter` to `register`