### PR TITLE
Added `defaultValue` to useFieldArray example

### DIFF
--- a/src/components/codeExamples/useFieldArray.ts
+++ b/src/components/codeExamples/useFieldArray.ts
@@ -14,7 +14,7 @@ function App() {
       <ul>
         {fields.map((item, index) => (
           <li key={item.id}>
-            <input name={\`test[\${index}].name\`} ref={register()} />
+            <input name={\`test[\${index}].name\`} defaultValue={item.name} ref={register()} />
             <button onClick={() => remove(index)}>Delete</button>
           </li>
         ))}


### PR DESCRIPTION
The current docs as misleading when they should `append({ name: "test" })` as if the initial value of the input would be `"test"`, while if no `defaultValue` is added to the input, the newly appended input will be empty by default.