### PR TITLE
Add JSON.stringify()

### DIFF
--- a/src/components/codeExamples/reactNative.ts
+++ b/src/components/codeExamples/reactNative.ts
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form'
 
 export default function App() {
   const { register, setValue, handleSubmit, errors } = useForm()
-  const onSubmit = data => Alert.alert('Form Data', data)
+  const onSubmit = data => Alert.alert('Form Data', JSON.stringify(data));
 
   return (
     <View>


### PR DESCRIPTION
Add JSON.stringify to prevent React Native error `Value for message cannot be case from ReadableNativeMap to String` when running `onSubmit` function