### PR TITLE
Fix advanced link on API page

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -1050,7 +1050,7 @@ const { register } = useForm<Inputs>({
             <button
               className={buttonStyles.primaryButton}
               onClick={() => {
-                navigate(translateLink("advanced-usage", currentLanguage))
+                navigate(translateLink("/advanced-usage", currentLanguage))
               }}
               style={{ margin: "40px auto" }}
             >

--- a/src/data/es/api-v5.tsx
+++ b/src/data/es/api-v5.tsx
@@ -391,7 +391,7 @@ export default {
         <p>
           <b className={typographyStyles.note}>Nota:</b> Puedes aprender más en{" "}
           <NavLink
-            to={translateLink("advanced-usage#ErrorMessage", currentLanguage)}
+            to={translateLink("/advanced-usage#ErrorMessage", currentLanguage)}
           >
             Mensaje de error
           </NavLink>{" "}

--- a/src/data/es/api.tsx
+++ b/src/data/es/api.tsx
@@ -403,7 +403,7 @@ export default {
         <p>
           <b className={typographyStyles.note}>Nota:</b> Puedes aprender más en{" "}
           <NavLink
-            to={translateLink("advanced-usage#ErrorMessage", currentLanguage)}
+            to={translateLink("/advanced-usage#ErrorMessage", currentLanguage)}
           >
             Mensaje de error
           </NavLink>{" "}


### PR DESCRIPTION
Currently, the button ("Learn Advanced Usage") at the end of API page https://react-hook-form.com/api/ is getting 404. This changes will fix the link.