### PR TITLE
Hide scroll to top button when Form Builder is open

### DIFF
--- a/src/components/BuilderPage.module.css
+++ b/src/components/BuilderPage.module.css
@@ -4,7 +4,7 @@
   left: 0;
   width: 100%;
   height: 100vh;
-  z-index: 4;
+  z-index: 11;
   box-sizing: border-box;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
When Form Builder is opened we can click button "scroll to top". After clicked "scroll to top" "close button" from a Form Builder overlap a language selector. In this PR has been changed z-index Form Builder "modal" which is higher than "scroll to top" button.