### PR TITLE
Fix typo in clearError code example

### DIFF
--- a/src/components/codeExamples/clearError.ts
+++ b/src/components/codeExamples/clearError.ts
@@ -2,7 +2,7 @@ export default `import React from "react";
 import { useForm } from "react-hook-form";
 
 export default () => {
-  const { clearError, errors, register, clearError } = useForm();
+  const { clearError, errors, register } = useForm();
 
   return (
     <form>


### PR DESCRIPTION
Remove duplicated import of clearError method