### PR TITLE
fix validation schema go to section

### DIFF
--- a/src/data/en/api-v5.tsx
+++ b/src/data/en/api-v5.tsx
@@ -37,7 +37,7 @@ export default {
         </p>
       </>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           This callback function allows you to run through any schema or custom
@@ -94,7 +94,7 @@ export default {
         significant impact on performances.
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           You can set the input's default value with{" "}
@@ -143,13 +143,13 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         Apply form validation rules with <code>Yup</code> at the schema level,
         please refer to the{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -184,7 +184,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         Setting this option to <code>true</code> will enable the browser's
         native validation. You can{" "}
@@ -271,7 +271,7 @@ export default {
       registerWithValidation: "Register with validation",
       registerWithValidationMessage:
         "Register with validation and error message",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>Custom Register</h2>
           <p>
@@ -371,7 +371,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>
           Object containing form errors and error messages corresponding to each
@@ -490,7 +490,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -37,7 +37,7 @@ export default {
         </p>
       </>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           This callback function allows you to run through any schema or custom
@@ -94,7 +94,7 @@ export default {
         significant impact on performances.
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           You can set the input's default value with{" "}
@@ -143,13 +143,13 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         Apply form validation rules with <code>Yup</code> at the schema level,
         please refer to the{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -184,7 +184,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         Setting this option to <code>true</code> will enable the browser's
         native validation. You can{" "}
@@ -271,7 +271,7 @@ export default {
       registerWithValidation: "Register with validation",
       registerWithValidationMessage:
         "Register with validation and error message",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>Custom Register</h2>
           <p>
@@ -383,7 +383,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>
           Object containing form errors and error messages corresponding to each
@@ -502,7 +502,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>
@@ -617,8 +617,7 @@ export default {
         </p>
         <p>
           You can also set the <code>shouldValidate</code> parameter to{" "}
-          <code>true</code>{" "}
-          in order to trigger a field validation. eg:{" "}
+          <code>true</code> in order to trigger a field validation. eg:{" "}
           <code>setValue('name', 'value', true)</code>
         </p>
       </>

--- a/src/data/es/api-v5.tsx
+++ b/src/data/es/api-v5.tsx
@@ -27,7 +27,7 @@ export default {
         siguiente ejemplo muestra todos los valores de las opciones por defecto.
       </p>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           Esta función de devolución de llamada le permite ejecutar cualquier
@@ -65,9 +65,9 @@ export default {
     validateCriteriaMode: (
       <>
         <p>
-          El comportamiento predeterminado <code>firstError</code>{" "}
-          realizará todas las validaciones de los campos y reunirá los primeros
-          errores encontrados.
+          El comportamiento predeterminado <code>firstError</code> realizará
+          todas las validaciones de los campos y reunirá los primeros errores
+          encontrados.
         </p>
         <p>
           Con la configuración seteada en <code>all</code>, se correran todas
@@ -95,7 +95,7 @@ export default {
         Considera que es una mala práctica de performance.
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           Puedes setear el valor por defecto del input con{" "}
@@ -146,13 +146,13 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         Aplica reglas de validación de formularios con <code> Yup </code>
         en el nivel de esquema, por favor refiérase a la sección{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -188,7 +188,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         Seteando esta opción en <code>true</code> habilitará la validación
         nativa del navegador. Puedes{" "}
@@ -277,7 +277,7 @@ export default {
       registerWithValidation: "Registro con validación",
       registerWithValidationMessage:
         "Registro con validación y mensaje de error",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>Registro personalizado</h2>
           <p>
@@ -381,7 +381,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>
           Objeto que contiene los errores de formulario o los mensajes de error
@@ -484,7 +484,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>

--- a/src/data/es/api.tsx
+++ b/src/data/es/api.tsx
@@ -27,7 +27,7 @@ export default {
         siguiente ejemplo muestra todos los valores de las opciones por defecto.
       </p>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           Esta función de devolución de llamada le permite ejecutar cualquier
@@ -95,7 +95,7 @@ export default {
         Considera que es una mala práctica de performance.
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           Puedes setear el valor por defecto del input con{" "}
@@ -146,13 +146,13 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         Aplica reglas de validación de formularios con <code> Yup </code>
         en el nivel de esquema, por favor refiérase a la sección{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -188,7 +188,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         Seteando esta opción en <code>true</code> habilitará la validación
         nativa del navegador. Puedes{" "}
@@ -277,7 +277,7 @@ export default {
       registerWithValidation: "Registro con validación",
       registerWithValidationMessage:
         "Registro con validación y mensaje de error",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>Registro personalizado</h2>
           <p>
@@ -393,7 +393,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>
           Objeto que contiene los errores de formulario o los mensajes de error
@@ -496,7 +496,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>

--- a/src/data/jp/api-v5.tsx
+++ b/src/data/jp/api-v5.tsx
@@ -28,7 +28,7 @@ export default {
         下記の例は、全てのオプションのデフォルト値を示します。
       </p>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           このコールバック関数を使用すると、任意のスキーマバリデーションまたはカスタムバリデーションを実行できます。
@@ -93,7 +93,7 @@ export default {
         非推奨: これをパフォーマンスの悪い習慣と考えてください。
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           <code>defaultValue/defaultChecked</code> を使用して input
@@ -143,13 +143,13 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         スキーマレベルで <code>Yup</code>{" "}
         を使用してフォームバリデーションルールを適用します。{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -184,7 +184,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         このオプションを <code>true</code>{" "}
         に設定すると、ブラウザーネイティブバリデーションが有効になります。
@@ -273,7 +273,7 @@ export default {
       title: "登録オプション",
       registerWithValidation: "バリデーションのみで登録",
       registerWithValidationMessage: "バリデーションとエラーメッセージで登録",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>カスタム登録</h2>
           <p>
@@ -383,7 +383,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>
           オブジェクトには、各 input{" "}
@@ -501,7 +501,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>

--- a/src/data/jp/api.tsx
+++ b/src/data/jp/api.tsx
@@ -28,7 +28,7 @@ export default {
         下記の例は、全てのオプションのデフォルト値を示します。
       </p>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           このコールバック関数を使用すると、任意のスキーマバリデーションまたはカスタムバリデーションを実行できます。
@@ -93,7 +93,7 @@ export default {
         非推奨: これをパフォーマンスの悪い習慣と考えてください。
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           <code>defaultValue/defaultChecked</code> を使用して input
@@ -143,13 +143,13 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         スキーマレベルで <code>Yup</code>{" "}
         を使用してフォームバリデーションルールを適用します。{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -184,7 +184,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         このオプションを <code>true</code>{" "}
         に設定すると、ブラウザーネイティブバリデーションが有効になります。
@@ -273,7 +273,7 @@ export default {
       title: "登録オプション",
       registerWithValidation: "バリデーションのみで登録",
       registerWithValidationMessage: "バリデーションとエラーメッセージで登録",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>カスタム登録</h2>
           <p>
@@ -395,7 +395,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>
           オブジェクトには、各 input{" "}
@@ -513,7 +513,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>

--- a/src/data/kr/api-v5.tsx
+++ b/src/data/kr/api-v5.tsx
@@ -20,7 +20,7 @@ export default {
         <code>useForm</code> 을 호출하여 다음의 메소드들을 사용할 수 있습니다..{" "}
       </>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           이 콜백 함수는 어떠한 스키마나 커스텀 유효성 검사 함수를 끼워넣어
@@ -91,7 +91,7 @@ export default {
         않습니다.
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           입력의 기본값을 <code>defaultValue/defaultChecked</code> 로 설정
@@ -140,12 +140,12 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         <code>Yup</code> 의 스키마 레벨 폼 유효성 검사 규칙을 적용 하세요.{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -179,7 +179,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         이 옵션을 <code>true</code> 로 설정하면 브라우저의 기본 유효성 검사가
         활성화됩니다.
@@ -265,7 +265,7 @@ export default {
       title: "Register Options",
       registerWithValidation: "유효성 검사와 함께 등록",
       registerWithValidationMessage: "유효성 검사 및 에러 메시지 등록",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>Custom Register</h2>
           <p>
@@ -360,7 +360,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>각 입력에 대한 폼 에러 혹은 에러 메시지를 가진 객체입니다.</p>{" "}
         <p>
@@ -475,7 +475,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>

--- a/src/data/kr/api.tsx
+++ b/src/data/kr/api.tsx
@@ -20,7 +20,7 @@ export default {
         <code>useForm</code> 을 호출하여 다음의 메소드들을 사용할 수 있습니다..{" "}
       </>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           이 콜백 함수는 어떠한 스키마나 커스텀 유효성 검사 함수를 끼워넣어
@@ -91,7 +91,7 @@ export default {
         않습니다.
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           입력의 기본값을 <code>defaultValue/defaultChecked</code> 로 설정
@@ -140,12 +140,12 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         <code>Yup</code> 의 스키마 레벨 폼 유효성 검사 규칙을 적용 하세요.{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -179,7 +179,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         이 옵션을 <code>true</code> 로 설정하면 브라우저의 기본 유효성 검사가
         활성화됩니다.
@@ -265,7 +265,7 @@ export default {
       title: "Register Options",
       registerWithValidation: "유효성 검사와 함께 등록",
       registerWithValidationMessage: "유효성 검사 및 에러 메시지 등록",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>Custom Register</h2>
           <p>
@@ -372,7 +372,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>각 입력에 대한 폼 에러 혹은 에러 메시지를 가진 객체입니다.</p>{" "}
         <p>
@@ -487,7 +487,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>

--- a/src/data/pt/api-v5.tsx
+++ b/src/data/pt/api-v5.tsx
@@ -27,7 +27,7 @@ export default {
         seguir demonstra todas as opções, com valor padrão.
       </p>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           Essa função de callback permite que você execute sua validação através
@@ -92,7 +92,7 @@ export default {
         como uma prática não performática.
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           Você pode setar o valor padrão do campoo com{" "}
@@ -142,13 +142,13 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         Aplique regras de validação do formulário com <code>Yup</code> a nível
         de esquema, por favor, verifique a seção{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -184,7 +184,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         Setar esta opção para <code>true</code> irá habilitar a validação nativa
         do navegador. Você pode{" "}
@@ -271,7 +271,7 @@ export default {
       registerWithValidation: "'Register' com validação",
       registerWithValidationMessage:
         "'Register' com validação e mensagem de erro",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>Register Customizado</h2>
           <p>
@@ -373,7 +373,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>
           Objeto contendo erros de formulário, ou mensagens de erro que
@@ -493,7 +493,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>

--- a/src/data/pt/api.tsx
+++ b/src/data/pt/api.tsx
@@ -27,7 +27,7 @@ export default {
         seguir demonstra todas as opções, com valor padrão.
       </p>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           Essa função de callback permite que você execute sua validação através
@@ -92,7 +92,7 @@ export default {
         como uma prática não performática.
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           Você pode setar o valor padrão do campoo com{" "}
@@ -142,13 +142,13 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         Aplique regras de validação do formulário com <code>Yup</code> a nível
         de esquema, por favor, verifique a seção{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -184,7 +184,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         Setar esta opção para <code>true</code> irá habilitar a validação nativa
         do navegador. Você pode{" "}
@@ -271,7 +271,7 @@ export default {
       registerWithValidation: "'Register' com validação",
       registerWithValidationMessage:
         "'Register' com validação e mensagem de erro",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>Register Customizado</h2>
           <p>
@@ -386,7 +386,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>
           Objeto contendo erros de formulário, ou mensagens de erro que
@@ -506,7 +506,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>

--- a/src/data/ru/api-v5.tsx
+++ b/src/data/ru/api-v5.tsx
@@ -26,7 +26,7 @@ export default {
         следующем примере приведены значения по умолчанию для всех параметров.
       </p>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           This callback function allow you to run through any schema or custom
@@ -90,7 +90,7 @@ export default {
         считается, что это ухудшает производительность.
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           Вы можете установить зачение по умолчанию для поля с помощью{" "}
@@ -140,13 +140,13 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         Применение правил валидации с <code>Yup</code> на уровне схемы,
         перейдите в раздел{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -182,7 +182,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         Устанавливая эту опцию в <code>true</code> включит нативную браузерную
         валидацию. Вы можете{" "}
@@ -272,7 +272,7 @@ export default {
       registerWithValidation: "Регистрация с валидацией",
       registerWithValidationMessage:
         "Регистрация с валидацией и сообщением об ошибке",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>Кастомная регистрация</h2>
           <p>
@@ -494,7 +494,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>
@@ -658,7 +658,7 @@ export default {
     ),
   },
   validationSchema: {
-    title: "ValidationSchema",
+    title: "validationSchema",
     description: (
       <p>
         Если вы хотите централизовать свои правила валидации с помощью внешней

--- a/src/data/ru/api.tsx
+++ b/src/data/ru/api.tsx
@@ -26,7 +26,7 @@ export default {
         следующем примере приведены значения по умолчанию для всех параметров.
       </p>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           This callback function allow you to run through any schema or custom
@@ -90,7 +90,7 @@ export default {
         считается, что это ухудшает производительность.
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           Вы можете установить зачение по умолчанию для поля с помощью{" "}
@@ -140,13 +140,13 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         Применение правил валидации с <code>Yup</code> на уровне схемы,
         перейдите в раздел{" "}
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>{" "}
@@ -182,7 +182,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         Устанавливая эту опцию в <code>true</code> включит нативную браузерную
         валидацию. Вы можете{" "}
@@ -272,7 +272,7 @@ export default {
       registerWithValidation: "Регистрация с валидацией",
       registerWithValidationMessage:
         "Регистрация с валидацией и сообщением об ошибке",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>Кастомная регистрация</h2>
           <p>
@@ -506,7 +506,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>
@@ -670,7 +670,7 @@ export default {
     ),
   },
   validationSchema: {
-    title: "ValidationSchema",
+    title: "validationSchema",
     description: (
       <p>
         Если вы хотите централизовать свои правила валидации с помощью внешней

--- a/src/data/zh/api-v5.tsx
+++ b/src/data/zh/api-v5.tsx
@@ -26,7 +26,7 @@ export default {
         下面的示例演示了所有选项的默认值。
       </p>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           该回调函数使您可以运行任何模式或自定义验证。该函数的完整形式为
@@ -95,7 +95,7 @@ export default {
         的事件上触发，并导致多个重新renders。 不推荐这个方法的实践性能。
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           您可以使用defaultValue/defaultChecked设置输入的默认值
@@ -143,12 +143,12 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         将表单验证规则应用于架构级别的<code>Yup</code>，请参阅验证架构
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>
@@ -180,7 +180,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         将此选项设置为<code>true</code>将启用浏览器的本机验证。{" "}
         <a
@@ -257,7 +257,7 @@ export default {
       title: "注册选项",
       registerWithValidation: "注册验证",
       registerWithValidationMessage: "注册验证和错误消息",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>手动注册输入</h2>
           <p>
@@ -363,7 +363,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>对象包含属于每个输入的表单错误或错误消息。</p>
 
@@ -474,7 +474,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>

--- a/src/data/zh/api.tsx
+++ b/src/data/zh/api.tsx
@@ -26,7 +26,7 @@ export default {
         下面的示例演示了所有选项的默认值。
       </p>
     ),
-    validationResolver: goToSection => (
+    validationResolver: (goToSection) => (
       <>
         <p>
           该回调函数使您可以运行任何模式或自定义验证。该函数的完整形式为
@@ -95,7 +95,7 @@ export default {
         的事件上触发，并导致多个重新renders。 不推荐这个方法的实践性能。
       </>
     ),
-    defaultValues: goToSection => (
+    defaultValues: (goToSection) => (
       <>
         <p>
           您可以使用defaultValue/defaultChecked设置输入的默认值
@@ -143,12 +143,12 @@ export default {
         </p>
       </>
     ),
-    validationSchema: goToSection => (
+    validationSchema: (goToSection) => (
       <p>
         将表单验证规则应用于架构级别的<code>Yup</code>，请参阅验证架构
         <button
           className={buttonStyles.codeAsLink}
-          onClick={() => goToSection("ValidationSchema")}
+          onClick={() => goToSection("validationSchema")}
         >
           validationSchema
         </button>
@@ -180,7 +180,7 @@ export default {
         </p>
       </>
     ),
-    nativeValidation: goToSection => (
+    nativeValidation: (goToSection) => (
       <p>
         将此选项设置为<code>true</code>将启用浏览器的本机验证。{" "}
         <a
@@ -257,7 +257,7 @@ export default {
       title: "注册选项",
       registerWithValidation: "注册验证",
       registerWithValidationMessage: "注册验证和错误消息",
-      note: goToSection => (
+      note: (goToSection) => (
         <>
           <h2 className={typographyStyles.title}>手动注册输入</h2>
           <p>
@@ -375,7 +375,7 @@ export default {
   },
   errors: {
     title: "errors",
-    description: currentLanguage => (
+    description: (currentLanguage) => (
       <>
         <p>对象包含属于每个输入的表单错误或错误消息。</p>
 
@@ -486,7 +486,7 @@ export default {
       </>
     ),
   },
-  reset: goToSection => ({
+  reset: (goToSection) => ({
     title: "reset",
     description: (
       <>


### PR DESCRIPTION
* Fix go to section validationSchema

P.S.
I have noticed @bluebill1049 you have upgraded packages (also Prettier) so https://prettier.io/docs/en/options.html#arrow-function-parentheses
> First available in v1.9.0, default value changed from avoid to always in v2.0.0

and thats why Prettier in precommit reformatted these files
