### PR TITLE
Update setError.ts

### DIFF
--- a/src/components/codeExamples/setError.ts
+++ b/src/components/codeExamples/setError.ts
@@ -2,7 +2,7 @@ export default `import React from "react";
 import { useForm } from "react-hook-form";
 
 export default function App() {
-  const { register, errors, setError } = useForm();
+  const { register, errors, setError, clearError } = useForm();
 
   return (
     <form>


### PR DESCRIPTION
Team,

This tiny change adds `clearError` that is referred in the code [here](https://github.com/react-hook-form/react-hook-form-website/compare/master...yuyokk:yuyokk-patch-1?expand=1#diff-364734f2911a3b413beb414a5d42856cR14)

Please let me know if this makes sense to you.
Thanks 