### PR TITLE
Fixed typo on Advanced Usage page

### DIFF
--- a/src/data/en/advanced.tsx
+++ b/src/data/en/advanced.tsx
@@ -40,8 +40,8 @@ export default {
         >
           Antd
         </a>{" "}
-        Besides, with React Hook Form the re-rendering of controlled component is
-        also optimized. Here is an example that combines controlled and
+        Besides, with React Hook Form the re-rendering of controlled component
+        is also optimized. Here is an example that combines controlled and
         uncontrolled form validation.
       </p>
     ),
@@ -51,18 +51,19 @@ export default {
     description: (
       <p>
         Error messages are visual feedback to our users when there are issues
-        with their inputs. React Hook Form provides an <code>errors</code>
-        object to let you retrieve errors easily. There are several
-        different ways to improve error presentation on the screen.
+        with their inputs. React Hook Form provides an <code>errors</code>{" "}
+        object to let you retrieve errors easily. There are several different
+        ways to improve error presentation on the screen.
       </p>
     ),
     register: (
       <>
-        You can simply pass the error message to <code>register</code>, via the
+        You can simply pass the error message to <code>register</code>, via the{" "}
         <code>message</code> attribute of the validation rule object, like this:
       </>
     ),
-    component: "Create an <code>ErrorMessage</code> component to help display the error.",
+    component:
+      "Create an <code>ErrorMessage</code> component to help display the error.",
     optionalChaining: (
       <>
         <p>
@@ -74,9 +75,9 @@ export default {
           >
             optional chaining
           </a>{" "}
-          operator permits reading the <code>errors</code>{" "}
-          object without worrying about causing another error due to <code>null</code>{" "}
-          or <code>undefined</code>.
+          operator permits reading the <code>errors</code> object without
+          worrying about causing another error due to <code>null</code> or{" "}
+          <code>undefined</code>.
         </p>
         <p>
           <code>{`errors?.firstName?.message`}</code>
@@ -356,8 +357,8 @@ export default {
       <>
         <p>
           React Hook Form makes dealing with conditional fields really simple
-          because when you remove the input from the component tree,
-          it will get <code>unregister</code>ed automatically.{" "}
+          because when you remove the input from the component tree, it will get{" "}
+          <code>unregister</code>ed automatically.{" "}
           <a
             href="https://codesandbox.io/s/13ykqx4wx7"
             target="_blank"


### PR DESCRIPTION
This PR is to fix the typo on the Advanced Usage page.

I fixed typo that was no space.
