### PR TITLE
Fixed APIPage link to navigate to Advanced Usage Page

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -1054,7 +1054,7 @@ const { register } = useForm<Inputs>({
             <button
               className={buttonStyles.primaryButton}
               onClick={() => {
-                navigate(translateLink("/advanced-usage", currentLanguage))
+                navigate(translateLink("advanced-usage", currentLanguage))
               }}
               style={{ margin: "40px auto" }}
             >


### PR DESCRIPTION
I fixed link to navigate to Advanced Usage Page.

The next page is not displayed if I clicked the "Learn Advanced Usage" button when translated to a language other than English.