### PR TITLE
Typo fix: `setValue` config options' description

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -1764,7 +1764,7 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
                         Whether to compute if your entire form is dirty or not
                         against your defaultValues (subscribed to{" "}
                         <code className={typographyStyles.typeText}>
-                          isDrirty
+                          isDirty
                         </code>
                         ).
                       </p>


### PR DESCRIPTION
Minor fix to the docs.
- Typo fix for `setValue` `shouldDirty` config option's description.

My first PR, hoping that's all I have to write in the description 😅 