### PR TITLE
Add `disabled` props to useWatch props signature

### DIFF
--- a/src/components/UseWatchContent.tsx
+++ b/src/components/UseWatchContent.tsx
@@ -22,7 +22,7 @@ export default function UseFieldArray({
           useWatch:{" "}
           <span
             className={typographyStyles.typeText}
-          >{`({ control?: Control, name?: string, defaultValue?: any }) => object`}</span>
+          >{`({ control?: Control, name?: string, defaultValue?: any, disabled?: boolean }) => object`}</span>
         </h2>
       </code>
 
@@ -82,7 +82,7 @@ export default function UseFieldArray({
             </tr>
             <tr>
               <td>
-                <code>disable</code>
+                <code>disabled</code>
               </td>
               <td>
                 <code className={typographyStyles.typeText}>


### PR DESCRIPTION
First of all: thanks for this great lib ! 

I catch what I think might be an error in the documentation : according to react-hook-form source code, `useWatch` takes the following object as argument:

```
export type UseWatchProps<TFieldValues extends FieldValues = FieldValues> = {
  defaultValue?: unknown;
  disabled?: boolean;
  name?:
    | FieldPath<TFieldValues>
    | FieldPath<TFieldValues>[]
    | readonly FieldPath<TFieldValues>[];
  control?: Control<TFieldValues>;
};
```
but `disabled` was missing and mispelled in the according documentation.

Hope this change is relevant.

Cheers
