### PR TITLE
fix: update wrong name in watch page

### DIFF
--- a/src/components/codeExamples/useWatch.ts
+++ b/src/components/codeExamples/useWatch.ts
@@ -17,7 +17,7 @@ function App() {
   return (
     <form onSubmit={handleSubmit(data => console.log("data", data))}>
       <input {...register("firstName")} />
-      <input {...register("last")} />
+      <input {...register("lastName")} />
       <IsolateReRender control={control} />
       
       <input type="submit" />

--- a/src/components/codeExamples/v6/useWatch.ts
+++ b/src/components/codeExamples/v6/useWatch.ts
@@ -17,7 +17,7 @@ function App() {
   return (
     <form onSubmit={handleSubmit(data => console.log("data", data))}>
       <input ref={register} name="firstName" />
-      <input ref={register} name="last" />
+      <input ref={register} name="lastName" />
       <IsolateReRender control={control} />
       
       <input type="submit" />


### PR DESCRIPTION
In this file, we have 
```
    name: 'firstName', // without supply name will watch the entire form, or ['firstName', 'lastName'] to watch both
```
However, the input name is `last` instead of `lastName`. I believe this is a typo.