### PR TITLE
Fix typo in rules doc of useController

### DIFF
--- a/src/data/en/advanced.tsx
+++ b/src/data/en/advanced.tsx
@@ -40,8 +40,8 @@ export default {
           rel="noopener noreferrer"
         >
           Antd
-        </a>.{" "}
-        Besides, with React Hook Form the re-rendering of controlled component
+        </a>
+        . Besides, with React Hook Form the re-rendering of controlled component
         is also optimized. Here is an example that combines them both with
         validation.
       </p>

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -1269,8 +1269,8 @@ reset({ deepNest: { file: new File() } });
                 <td>
                   <p>
                     <code>DirtyFields</code> form state will remain, and{" "}
-                    <code>isDirty</code> will temporarily remain as the
-                    current state until further user's action.
+                    <code>isDirty</code> will temporarily remain as the current
+                    state until further user's action.
                   </p>
 
                   <p>
@@ -2890,8 +2890,7 @@ append({ firstName: 'bill', lastName: 'luo' }); ✅`}
             </p>
             <p>
               <b className={typographyStyles.note}>Important:</b> doesn't
-              support
-              <code>valueAs</code> for <code>useController</code>.
+              support <code>valueAs</code> for <code>useController</code>.
             </p>
             <CodeArea
               url="https://codesandbox.io/s/controller-rules-8pd7z?file=/src/App.tsx"


### PR DESCRIPTION
Hello guys,

Here is a little PR to fix a little typo visible here:
![image](https://user-images.githubusercontent.com/17161484/138825540-0a269ea3-922f-4bf1-bc44-61c6d0569203.png)

After edit:
![image](https://user-images.githubusercontent.com/17161484/138825627-564bfcc5-78e6-49e4-bfd7-02b0e05076e2.png)

There are some another changes due to pre-commit process (`yarn prettier` I guess) but the main change is this one: https://github.com/react-hook-form/documentation/pull/685/files#diff-99218300a09592110794f7a48501074b7b40e48144338d1f4e49aa76630e8952R2893

Have a good day