### PR TITLE
Adding missing arrow (=>)

### DIFF
--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -390,7 +390,7 @@ export default function ApiRefTable({ api }) {
         : `{
       positive: v => parseInt(v) > 0 || 'should be greater than 0',
       lessThanTen: v => parseInt(v) < 10 || 'should be lower than 10',
-      validateNumber: (_: number, formValues: FormValues) {
+      validateNumber: (_: number, formValues: FormValues) => {
         return formValues.number1 + formValues.number2 === 3 || 'Check sum number';
       },
       // you can do asynchronous validation as well


### PR DESCRIPTION
Adding missing arrow (=>) in the validateNumber function Line number 393. I was running the examples in my local when I found out that the **validateNumber** is an arrow function with missing arrow. We can either put **function** keyword in front of the method or add arrow **=>** in it, so I have added the arrow.