### PR TITLE
Add note to Controller documentation - FE-1221

### DIFF
--- a/src/content/docs/usecontroller/controller.mdx
+++ b/src/content/docs/usecontroller/controller.mdx
@@ -8,6 +8,8 @@ sidebar: apiLinks
 
 React Hook Form embraces uncontrolled components and native inputs, however it's hard to avoid working with external controlled component such as [React-Select](https://github.com/JedWatson/react-select), [AntD](https://github.com/ant-design/ant-design) and [MUI](https://mui.com/). This wrapper component will make it easier for you to work with them.
 
+**Note:** if you simply want to control a field's value from outside the form, it's not necessary to use `Controller`. You can simply use the [`values`](/docs/useform#values) option of `useForm`.
+
 ### Props
 
 ---

--- a/src/data/api.tsx
+++ b/src/data/api.tsx
@@ -787,11 +787,7 @@ setValue('test', '')
         Set to <code>true</code> during validation.
       </>
     ),
-    validatingFields: (
-      <>
-        Capture fields which are getting async validation.
-      </>
-    ),
+    validatingFields: <>Capture fields which are getting async validation.</>,
   },
   errors: {
     title: "errors",
@@ -2935,6 +2931,15 @@ const { field: checkbox } = useController({ name: 'test1' })
           . Additionally, it shares the same props and methods as{" "}
           <code>Controller</code>. It's useful for creating reusable Controlled
           input.
+        </p>
+        <p>
+          <strong>Note:</strong> if you simply want to control a field's value
+          from outside the form, it's not necessary to use{" "}
+          <code>useController</code>. You can simply use the{" "}
+          <Link href="/docs/useform#values">
+            <code>values</code>
+          </Link>{" "}
+          option of <code>useForm</code>.
         </p>
       </>
     ),


### PR DESCRIPTION
I was implementing a feature recently where I needed to control the value of a dropdown menu via a state variable that existed outside the form. I eventually realized the most efficient way to do this was to use the `values` option of `useForm`. This PR adds a note to hopefully make that clearer for others.