### PR TITLE
Warn users that resetting the form while passing values will also reset defaultValues

### DIFF
--- a/src/content/docs/useform/reset.mdx
+++ b/src/content/docs/useform/reset.mdx
@@ -29,7 +29,7 @@ Reset the entire form state, fields reference, and subscriptions. There are opti
 
 <Admonition type="important" title="Rules">
 
-- For controlled components you will need to pass `defaultValues` to `useForm` in order to `reset` the `Controller` components' value.
+- For controlled components you will need to pass `defaultValues` to `useForm` in order to `reset` the `Controller` components' value & and default value.
 - When `defaultValues` is not supplied to `reset` API, then HTML native [reset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset) API will be invoked to restore the form.
 - Avoid calling `reset` before `useForm`'s `useEffect` is invoked, this is because `useForm`'s subscription needs to be ready before `reset` can send a signal to flush form state update.
 - It's recommended to `reset` inside `useEffect` after submission.
@@ -49,6 +49,7 @@ Reset the entire form state, fields reference, and subscriptions. There are opti
 
   reset(undefined, { keepDirtyValues: true }) // reset other form state but keep defaultValues and form values
   ```
+- Calling `reset` with `values` updates the form's `defaultValues` unless `options.keepDefaultValues` is set. If `reset` is later called without `values` or with `{}`, the form resets to the last `values` provided instead of the initial `defaultValues`
 
 </Admonition>
 

--- a/src/content/docs/useform/reset.mdx
+++ b/src/content/docs/useform/reset.mdx
@@ -29,7 +29,7 @@ Reset the entire form state, fields reference, and subscriptions. There are opti
 
 <Admonition type="important" title="Rules">
 
-- For controlled components you will need to pass `defaultValues` to `useForm` in order to `reset` the `Controller` components' value
+- For controlled components you will need to pass `defaultValues` to `useForm` in order to `reset` the `Controller` components' value.
 - When `defaultValues` is not supplied to `reset` API, then HTML native [reset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset) API will be invoked to restore the form.
 - Avoid calling `reset` before `useForm`'s `useEffect` is invoked, this is because `useForm`'s subscription needs to be ready before `reset` can send a signal to flush form state update.
 - It's recommended to `reset` inside `useEffect` after submission.

--- a/src/content/docs/useform/reset.mdx
+++ b/src/content/docs/useform/reset.mdx
@@ -29,7 +29,7 @@ Reset the entire form state, fields reference, and subscriptions. There are opti
 
 <Admonition type="important" title="Rules">
 
-- For controlled components you will need to pass `defaultValues` to `useForm` in order to `reset` the `Controller` components' value & and default value.
+- For controlled components you will need to pass `defaultValues` to `useForm` in order to `reset` the `Controller` components' value
 - When `defaultValues` is not supplied to `reset` API, then HTML native [reset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset) API will be invoked to restore the form.
 - Avoid calling `reset` before `useForm`'s `useEffect` is invoked, this is because `useForm`'s subscription needs to be ready before `reset` can send a signal to flush form state update.
 - It's recommended to `reset` inside `useEffect` after submission.


### PR DESCRIPTION
Added documentation that warns users that when calling `reset` with `values`, the form's `defaultValues` updates accordingly, which means subsequent calls to `reset` will use the previously passed `values` instead of the form's original `defaultValues`. This helps developers who call `reset` with API responses to be aware that subsequent `reset` only revert back to that API response