### PR TITLE
fixed typo in useForm

### DIFF
--- a/src/content/docs/useform.mdx
+++ b/src/content/docs/useform.mdx
@@ -329,7 +329,7 @@ This config will enable [browser native validation](https://developer.mozilla.or
 
 - Only works with `onSubmit` and `onChange` modes, as the `reportValidity` execution will focus the error input.
 - Each registered field's validation message is required to be string to display them natively.
-- This feature only works with the `register` API and `useController/Controller` that are connected with actual DOM references.
+- This feature only works with the `register` API and&nbsp; `useController/Controller` that are connected with actual DOM references.
 
 **Examples:**
 


### PR DESCRIPTION
## typo was in shouldUseNativeValidation section 

This feature only works with the register API anduseController/Controller that

the space between "API and" and "useController/Controller" was missinig in the website version of documentaion

before 
<img width="1185" height="301" alt="before" src="https://github.com/user-attachments/assets/fb7c6b80-3d38-4fdd-896a-0bfbe5be0201" />

after
<img width="1205" height="315" alt="after" src="https://github.com/user-attachments/assets/5fdf823c-edec-4a10-a344-ad259d0b6b01" />
