### PR TITLE
docs: Fix incorrect code examples in TypeScript support documentation

### DIFF
--- a/src/content/ts.mdx
+++ b/src/content/ts.mdx
@@ -101,8 +101,8 @@ export default function App() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit, onError)}>
-      <input {...(register("firstName"), { required: true })} />
-      <input {...(register("lastName"), { minLength: 2 })} />
+      <input {...register("firstName", { required: true })} />
+      <input {...register("lastName", { minLength: 2 })} />
       <input type="email" {...register("email")} />
 
       <input type="submit" />
@@ -547,7 +547,7 @@ export type FormStateProxy<TFieldValues extends FieldValues = FieldValues> = {
 
 ```tsx copy sandbox="https://codesandbox.io/s/react-hook-form-nestedvalue-lskdv"
 import { useForm, NestedValue } from "react-hook-form"
-import { Autocomplete, TextField, Select } from "@material-ui/core"
+import { TextField, Select } from "@material-ui/core"
 import { Autocomplete } from "@material-ui/lab"
 
 type Option = {
@@ -602,7 +602,7 @@ export default function App() {
 
       <Select
         value=""
-        onChange={(e) => setValue("muiSelect", e.target.value as number[])}
+        onChange={(e) => setValue("select", e.target.value as number[])}
       >
         <MenuItem value={10}>Ten</MenuItem>
         <MenuItem value={20}>Twenty</MenuItem>


### PR DESCRIPTION
## Summary  
  
This PR fixes three code errors in the TypeScript support documentation:  
  
1. **SubmitErrorHandler example**: Fixed incorrect `register()` usage where the return value wasn't being spread properly due to comma operator misuse  
2. **NestedValue example**: Removed duplicate `Autocomplete` import from `@material-ui/core` (it only exists in `@material-ui/lab`)  
3. **NestedValue example**: Fixed field name mismatch where `setValue("muiSelect", ...)` was used but the form type only defines a `select` field  
  
## Changes  
  
- Fixed register spread syntax from `{...(register("firstName"), { required: true })}` to `{...register("firstName", { required: true })}`  
- Removed duplicate `Autocomplete` import from `@material-ui/core`  
- Changed `setValue("muiSelect", ...)` to `setValue("select", ...)`