### PR TITLE
docs: Fix documentation errors in FAQ page  

### DIFF
--- a/src/content/faqs.mdx
+++ b/src/content/faqs.mdx
@@ -168,11 +168,10 @@ export default function App() {
   const onSubmit = (data) => console.log(data)
   const { ref, ...rest } = register("firstName")
   const onClick = () => {
-    firstNameRef.current!.value = ""
+    firstNameRef.current.value = ""
   }
 
   useImperativeHandle(ref, () => firstNameRef.current)
-
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -207,7 +206,7 @@ export default function App() {
   useEffect(() => {
     register("firstName", { required: true })
     register("lastName")
-  }, [])
+  }, [register])
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -240,18 +239,11 @@ Make sure you are not using `value`. The correct property is `defaultValue`.
 
 React Hook Form is focusing on uncontrolled inputs, which means you don't need to change the input `value` via `state` via `onChange`. In fact, you don't need `value` at all. You only need to set `defaultValue` for the initial input value.
 
-```javascript
-import { useForm } from "react-hook-form/dist/index.ie11" // V6
-import { useForm } from "react-hook-form/dist/react-hook-form.ie11" // V5'
-// Resolvers
-import { yupResolver } from "@hookform/resolvers/dist/ie11/yup"
-```
-
 ---
 
 ## React Hook Form, Formik or Redux Form? {#ReactHookFormFormikorReduxForm}
 
-First of all, all libs try to solve the same problem: make the form building experience as easy as possible. However, there are some fundamental differences between these three. `react-hook-form` is built with uncontrolled inputs in mind and tries to provide your form with the best performance and least amount of re-renders possible. Additionallly, `react-hook-form` is built with React Hooks and used as a hook, which means there is no Component for you to import. Here are some of the detailed differences:
+First of all, all libs try to solve the same problem: make the form building experience as easy as possible. However, there are some fundamental differences between these three. `react-hook-form` is built with uncontrolled inputs in mind and tries to provide your form with the best performance and least amount of re-renders possible. Additionally, `react-hook-form` is built with React Hooks and used as a hook, which means there is no Component for you to import. Here are some of the detailed differences:
 
 |                    | React Hook Form                                                                                                                                                                                              | Formik                                                                 | Redux Form                                                                              |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
@@ -303,7 +295,7 @@ It's important to understand that React Hook Form embraces native form behavior 
 - [Modal form and toggle inputs example](https://codesandbox.io/s/react-hook-form-modal-form-conditional-inputs-c7n0r)
 - [Tab form example](https://codesandbox.io/s/tabs-760h9)
 
-Alternatively you can use the deprecated option `shouldUnregister: false` when calling \`useForm\`.
+Alternatively you can use the deprecated option `shouldUnregister: false` when calling `useForm`.
 
 <TabGroup buttonLabels={["Controller", "Custom Register"]}>
 


### PR DESCRIPTION
## Summary  
  
This PR fixes several documentation errors found in the FAQ page, including typos, JavaScript syntax errors, React Hook dependency issues, markdown escaping problems, and misplaced code examples.  

## Changes  
  
### 1. Fixed typo in "React Hook Form, Formik or Redux Form?" section  
Changed "Additionallly" to "Additionally" (removed extra 'l').  
  
### 2. Fixed JavaScript syntax in "How to share ref usage?" section  
The JavaScript example incorrectly used TypeScript's non-null assertion operator (`!`).
  
### 3. Fixed React Hook dependency in "What if you don't have access to ref?" section  
Added missing `register` dependency to the `useEffect` hook dependency array to comply with React Hooks rules.  
  
### 4. Fixed markdown escaping in "How to work with modal or tab forms?" section  
Removed unnecessary backslash escaping from inline code around `useForm`.  
  
### 5. Removed misplaced code in "Why is the first keystroke not working?" section  
Removed IE11 import examples that were unrelated to the question about first keystroke issues. These imports don't provide relevant information for troubleshooting the `value` vs `defaultValue` problem described in the section.  

