### PR TITLE
docs: fix code examples in advanced-usage.mdx

### DIFF
--- a/src/content/advanced-usage.mdx
+++ b/src/content/advanced-usage.mdx
@@ -381,7 +381,7 @@ function App() {
 
       <Input {...register("input")} />
 
-      <button type="button" onClick={() => reset({ defaultValues })}>
+      <button type="button" onClick={() => reset({ ...defaultValues })}>
         Reset
       </button>
       <input type="submit" />
@@ -408,7 +408,7 @@ function App() {
   const onSubmit = (data) => console.log(data)
 
   useEffect(() => {
-    register({ name: "select" })
+    register("select")
   }, [register])
 
   const handleChange = (e) => setValue("select", e.target.value)
@@ -521,7 +521,12 @@ const items = Array.from(Array(1000).keys()).map((i) => ({
 const WindowedRow = memo(({ index, style, data }) => {
   const { register } = useFormContext()
 
-  return <input {...register(`${index}.quantity`)} />
+  return (
+    <div style={style}>
+      <label>{data[index].title}</label>
+      <input {...register(`${index}.quantity`)} />
+    </div>
+  )
 })
 
 export const App = () => {


### PR DESCRIPTION
## Summary  
  
This PR fixes three documentation issues in the `advanced-usage.mdx` file with incorrect or outdated code examples.  

## Changes  
  
1. **Fixed reset defaultValues usage in "Controlled mixed with Uncontrolled Components" section**  
   - Changed `reset({ defaultValues })` to `reset({ ...defaultValues })`  
   - The reset function expects the values directly, not wrapped in an object  
  
2. **Updated register API syntax in "Custom Register" example**  
   - Changed `register({ name: "select" })` to `register("select")`  
   - Simplified to match current API where field name is passed as first argument  
  
3. **Added style prop to virtualized list example in "Working with virtualized lists" section**  
   - Added `style={style}` to the WindowedRow component's return statement  
   - Wrapped input in a div with proper styling for react-window compatibility  
   - Matches the CodeSandbox example implementation