### PR TITLE
fix: mobile nav to API sub-pages

### DIFF
--- a/src/content/docs/useformstate.mdx
+++ b/src/content/docs/useformstate.mdx
@@ -8,7 +8,11 @@ sidebar: apiLinks
   options={[
     {
       label: "FormStateSubscribe",
-      value: "/docs/formstatesubscribe",
+      value: "/docs/useformstate/formstatesubscribe",
+    },
+    {
+      label: "ErrorMessage",
+      value: "/docs/useformstate/errormessage",
     },
   ]}
 />

--- a/src/content/docs/usewatch.mdx
+++ b/src/content/docs/usewatch.mdx
@@ -4,6 +4,15 @@ description: React Hook for subscribing to input changes
 sidebar: apiLinks
 ---
 
+<SelectNav
+  options={[
+    {
+      label: "Watch",
+      value: "/docs/usewatch/watch",
+    }
+  ]}
+/>
+
 ## \</> `useWatch:` <TypeText>`({ control?: Control, name?: string, defaultValue?: unknown, disabled?: boolean }) => object`</TypeText>
 
 Behaves similarly to the `watch` API, however, this will isolate re-rendering at the custom hook level and potentially result in better performance for your application.


### PR DESCRIPTION
##  Description
There was no way to easily access these pages on mobile since the nav was either incorrect or missing.

## Result

https://github.com/user-attachments/assets/61c9b180-84e7-4036-bede-48b9697e2138

