### PR TITLE
Replace input with TextField in Controller render

### DIFF
--- a/src/content/docs/useform/control.mdx
+++ b/src/content/docs/useform/control.mdx
@@ -35,7 +35,7 @@ function App() {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Controller
-        render={({ field }) => <input {...field} />}
+        render={({ field }) => <TextField {...field} />}
         name="firstName"
         control={control}
         defaultValue=""


### PR DESCRIPTION
Documentation is using the TextField from MUI as an example as stated by the import, but it's not used in the example.