### PR TITLE
docs: clarify useFormContext formState subscriptions

### DIFF
--- a/src/content/docs/useformcontext.mdx
+++ b/src/content/docs/useformcontext.mdx
@@ -34,6 +34,12 @@ const methods = useFormContext() // retrieve those props
 <Admonition type="important" title="Rules">
   You need to wrap your form with the [`FormProvider`](/docs/formprovider)
   component for `useFormContext` to work properly.
+
+  If you need to subscribe to form state values like `errors`, `isDirty`, or
+  `dirtyFields` inside a `FormProvider` tree, use
+  [`useFormState`](/docs/useformstate) instead of destructuring `formState`
+  from `useFormContext()`. `formState` is wrapped with a Proxy, so you should
+  read the specific state you want to subscribe to before render.
 </Admonition>
 
 **Example:**

--- a/src/content/docs/useformcontext.mdx
+++ b/src/content/docs/useformcontext.mdx
@@ -35,11 +35,12 @@ const methods = useFormContext() // retrieve those props
   You need to wrap your form with the [`FormProvider`](/docs/formprovider)
   component for `useFormContext` to work properly.
 
-  If you need to subscribe to form state values like `errors`, `isDirty`, or
-  `dirtyFields` inside a `FormProvider` tree, use
-  [`useFormState`](/docs/useformstate) instead of destructuring `formState`
-  from `useFormContext()`. `formState` is wrapped with a Proxy, so you should
-  read the specific state you want to subscribe to before render.
+If you need to subscribe to form state values like `errors`, `isDirty`, or
+`dirtyFields` inside a `FormProvider` tree, use
+[`useFormState`](/docs/useformstate) instead of destructuring `formState`
+from `useFormContext()`. `formState` is wrapped with a Proxy, so you should
+read the specific state you want to subscribe to before render.
+
 </Admonition>
 
 **Example:**


### PR DESCRIPTION
## Summary
- document that `formState` values accessed through `useFormContext()` inside a `FormProvider` tree do not establish subscriptions on their own
- recommend `useFormState` when subscribing to values like `errors`, `isDirty`, and `dirtyFields`

Fixes #1193.

## Testing
- reviewed the updated docs copy in `src/content/docs/useformcontext.mdx`
- verified the diff is limited to the `useFormContext` rules section