### PR TITLE
docs: document type values for watch() callback

### DIFF
--- a/src/content/docs/useform/watch.mdx
+++ b/src/content/docs/useform/watch.mdx
@@ -85,6 +85,10 @@ Subscribe to field update/change without trigger re-render.
 
 **Returns** object with `unsubscribe` function.
 
+**Callback arguments**
+
+The `type` argument indicates the originating DOM event (typed as `EventType`). For standard web inputs, this is `'change'` when a user updates a field. `type` is `undefined` when the change was triggered programmatically (e.g., via `setValue`, `reset`, or after `unregister`). See [`EventType`](https://github.com/react-hook-form/react-hook-form/blob/master/src/types/events.ts) for the full union (which includes React Native event types).
+
 ### Rules
 
 ---


### PR DESCRIPTION
Closes #1040.

The deprecated `watch(callback, ...)` overload's `type` argument was undocumented. Adds a short note clarifying:
- `type` is the originating DOM event (typed as [`EventType`](https://github.com/react-hook-form/react-hook-form/blob/master/src/types/events.ts))
- For standard web inputs, `type === 'change'` on user input
- `type === undefined` when triggered programmatically (`setValue`, `reset`, `unregister`)
- Full union also includes React Native event types