### PR TITLE
docs: correct setError error argument type signature

### DIFF
--- a/src/content/docs/useform/seterror.mdx
+++ b/src/content/docs/useform/seterror.mdx
@@ -4,7 +4,7 @@ description: Manually set an input error
 sidebar: apiLinks
 ---
 
-## \</> `setError:` <TypeText>`(name: string, error: FieldError, { shouldFocus?: boolean }) => void`</TypeText>
+## \</> `setError:` <TypeText>`(name: string, error: ErrorOption, { shouldFocus?: boolean }) => void`</TypeText>
 
 The function allows you to manually set one or more errors.
 
@@ -15,7 +15,7 @@ The function allows you to manually set one or more errors.
 | Name    | Type                                                                                  | Description                                                                                                                                             |
 | ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`  | <TypeText>string</TypeText>                                                           | input's name.                                                                                                                                           |
-| `error` | <TypeText>`{ type: string, message?: string, types: MultipleFieldErrors }`</TypeText> | Set an error with its type and message.                                                                                                                 |
+| `error` | <TypeText>`{ type?: string, message?: string, types?: MultipleFieldErrors }`</TypeText> | Set an error with its type and message.                                                                                                                 |
 | config  | <TypeText>`{ shouldFocus?: boolean }`</TypeText>                                      | Should focus the input during setting an error. This only works when the input's reference is registered, it will not work for custom register as well. |
 
 <Admonition type="important" title="Rules">

--- a/src/content/docs/useform/seterror.mdx
+++ b/src/content/docs/useform/seterror.mdx
@@ -12,11 +12,11 @@ The function allows you to manually set one or more errors.
 
 ---
 
-| Name    | Type                                                                                  | Description                                                                                                                                             |
-| ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`  | <TypeText>string</TypeText>                                                           | input's name.                                                                                                                                           |
+| Name    | Type                                                                                    | Description                                                                                                                                             |
+| ------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`  | <TypeText>string</TypeText>                                                             | input's name.                                                                                                                                           |
 | `error` | <TypeText>`{ type?: string, message?: string, types?: MultipleFieldErrors }`</TypeText> | Set an error with its type and message.                                                                                                                 |
-| config  | <TypeText>`{ shouldFocus?: boolean }`</TypeText>                                      | Should focus the input during setting an error. This only works when the input's reference is registered, it will not work for custom register as well. |
+| config  | <TypeText>`{ shouldFocus?: boolean }`</TypeText>                                        | Should focus the input during setting an error. This only works when the input's reference is registered, it will not work for custom register as well. |
 
 <Admonition type="important" title="Rules">
 


### PR DESCRIPTION
The `setError` docs describe the second argument as `FieldError` with `type` and `types` marked as required. Both are wrong against the library source.

The argument type is `ErrorOption`, not `FieldError` (see [`UseFormSetError` in `src/types/form.ts:644`](https://github.com/react-hook-form/react-hook-form/blob/master/src/types/form.ts#L644)). All three fields on `ErrorOption` are optional ([`src/types/errors.ts:21-25`](https://github.com/react-hook-form/react-hook-form/blob/master/src/types/errors.ts#L21-L25)):

```ts
export type ErrorOption = {
  message?: Message;
  type?: LiteralUnion<keyof RegisterOptions, string>;
  types?: MultipleFieldErrors;
};
```

`FieldError` is a different type (the shape of entries on `formState.errors`), so the current wording also pointed at the wrong thing.

Two content changes in `src/content/docs/useform/seterror.mdx`: the signature line (`error: FieldError` to `error: ErrorOption`) and the `error` props row (optional markers on `type` and `types`). Prettier reflowed the table column widths; split into a second commit matching the repo's format-as-follow-up pattern.

Addresses point 1 from #1065. The other points (`types` usage details, "Multiple Errors" naming, nested-merge behavior) need separate verification and are out of scope here.