### PR TITLE
docs: clarify register validation rules vs native HTML attributes

### DIFF
--- a/src/content/docs/useform/register.mdx
+++ b/src/content/docs/useform/register.mdx
@@ -47,6 +47,12 @@ This is how submitted values will look like:
 
 By selecting the register option, the API table below will get updated.
 
+<Admonition type="note">
+
+These are validation rules, not native HTML attributes. They run based on the form's [`mode`](/docs/useform#mode) and don't block typing. To also forward `required`, `min`, `max`, `minLength`, `maxLength`, and `pattern` as native attributes on the input, set [`progressive`](/docs/useform/form) to `true` on `useForm`.
+
+</Admonition>
+
 <TabGroup buttonLabels={["validation", "validation and error message"]}>
 
 <div style={{ background: 'var(--color-options)', padding: 20 }}>


### PR DESCRIPTION
Closes #1043.

The register Options table doesn't say whether the listed entries (`required`, `maxLength`, etc.) are validation rules or native HTML attributes. They're validation rules tied to `mode`; the native HTML attributes only get forwarded when `progressive: true` is set on `useForm` (see `src/logic/createFormControl.ts:1111-1119` in the library repo, which is also already linked from `useform.mdx:101` and documented at `useform/form.mdx:62-78`).

Adds a 4-line `note` admonition above the `TabGroup` so it applies to both tabs. No row text changes, no prettier reflow.
