### PR TITLE
docs: sync UseFormProps type with current source (add validate, formControl)

### DIFF
--- a/src/content/ts.mdx
+++ b/src/content/ts.mdx
@@ -285,6 +285,11 @@ export type UseFormProps<
   progressive: boolean
   criteriaMode: CriteriaMode
   delayError: number
+  formControl?: Omit<
+    UseFormReturn<TFieldValues, TContext, TTransformedValues>,
+    "formState"
+  >
+  validate: ValidateForm<TFieldValues>
 }>
 ```
 


### PR DESCRIPTION
Related to #1178.

The `UseFormProps` type block on the `/ts` page is missing two fields that have shipped: `validate` and `formControl`. Source has both at `src/types/form.ts:130-134` (verified against the v7.73.0 tag, the latest released).

- `validate: ValidateForm<TFieldValues>` is the form-level `validate` API already documented at `useform.mdx:283-290` as a `useForm` option. `ValidateForm` is publicly re-exported via `src/index.ts -> src/types -> src/types/validator.ts`.
- `formControl?: Omit<UseFormReturn<...>, 'formState'>` is consumed at `src/useForm.ts:69-86` when passed (it spreads into the internal control and runs `formControl.reset(defaultValues, resetOptions)` on change). PR #12878 was a bugfix on this exact prop, confirming it as a public option.

Adds those two fields to the type block so the signature on `/ts` matches source. Out of scope: the generic parameter constraints in the docs block (`TContext extends object = object`, `TTransformedValues extends FieldValues | undefined = undefined`) differ stylistically from source (`TContext = any`, `TTransformedValues = TFieldValues`); not changing those here.
