### PR TITLE
docs: fix indefinite article in setFocus name description

### DIFF
--- a/src/content/docs/useform/setfocus.mdx
+++ b/src/content/docs/useform/setfocus.mdx
@@ -15,7 +15,7 @@ This method will allow users to programmatically focus on input. Make sure input
 
 | Name      |                | Type                         | Description                                   |
 | --------- | -------------- | ---------------------------- | --------------------------------------------- |
-| `name`    |                | <TypeText>string</TypeText>  | A input field name to focus                   |
+| `name`    |                | <TypeText>string</TypeText>  | An input field name to focus                  |
 | `options` | `shouldSelect` | <TypeText>boolean</TypeText> | Whether to select the input content on focus. |
 
 <Admonition type="important" title="Rules">


### PR DESCRIPTION
The `name` prop description on the setFocus page reads "A input field name to focus". "input" takes "an", so this should be "An input field name to focus".
