### PR TITLE
add `react-hook-form-file-upload` to 3rd party resources

### DIFF
--- a/src/data/resources.tsx
+++ b/src/data/resources.tsx
@@ -1035,5 +1035,12 @@ export default {
       description:
         "Small project based on react-hook-form that exposes an API for easily creating customizable forms based on a JSON Schema with built-in validation.",
     },
+    {
+      type: "binding",
+      url: "https://git.gay/singingwolfboy/react-hook-form-file-upload",
+      title: "File Uploads for React Hook Form",
+      description:
+        "Simplify file uploads by allowing the client to upload files directly to your object store. Let React Hook Form manage file references, instead of the files themselves.",
+    },
   ],
 }


### PR DESCRIPTION
I wrote [`react-hook-form-file-upload`](https://git.gay/singingwolfboy/react-hook-form-file-upload) to formalize a pattern I was using with React Hook Form. It's a small library, and most of the value is in the documentation, rather than the code itself. Nonetheless, it feels like a helpful pattern, so I've [published the code on npm](https://www.npmjs.com/package/react-hook-form-file-upload).

I wanted to add this to the documentation, so that other developers can find and use it. Please let me know if there's anything else I need to do to get this code reviewed and merged. Thank you!