### PR TITLE
fix: update "Star us on GitHub" button URL

### DIFF
--- a/src/components/StarRepo.tsx
+++ b/src/components/StarRepo.tsx
@@ -17,7 +17,7 @@ export default function StarRepo() {
         className={buttonStyles.primaryButton}
         onClick={() => {
           window.open(
-            "https://github.com/react-hook-form/react-hook-form/stargazers"
+            "https://github.com/react-hook-form/react-hook-form"
           )
         }}
         style={{ margin: "40px auto" }}


### PR DESCRIPTION
## Summary

This PR fixes the "Star us on GitHub" button by updating its URL to the repository page. Previously, clicking the button opened a GitHub URL that resulted in a 404 page.

## Star us on Github Button 
<img width="870" height="314" alt="Get Started React Hook Form star us on github button" src="https://github.com/user-attachments/assets/b18d5cd4-d0ad-43c1-bf99-f9c53d4e26e4" />


## Before

Clicking the button opened a broken GitHub URL.

<img width="918" height="394" alt="404 Page not found · GitHub" src="https://github.com/user-attachments/assets/6aae8eab-13bd-4da2-9a4f-66c7a83acad3" />


## After

Clicking the button now opens the React Hook Form GitHub repository successfully.

<img width="1311" height="693" alt="react-hook-form github page " src="https://github.com/user-attachments/assets/d093ca72-8aff-4ed0-8915-c1ed6c1a47ec" />


## Testing

- Verified the issue locally.
- Updated the GitHub URL.
- Confirmed that clicking the button now opens the correct repository page.
