### PR TITLE
fix: add sponsor text in light mode

### DIFF
--- a/src/components/sponsorsList.module.css
+++ b/src/components/sponsorsList.module.css
@@ -13,7 +13,7 @@
 }
 
 .root a {
-  color: white;
+  color: var(--color-text);
   text-decoration: none;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Issues
- 'Sponsor add' text in button is blinded in light mode

<img width="363" height="193" alt="image" src="https://github.com/user-attachments/assets/29ddc7c9-f459-4e2c-b126-43bef43e1d2d" />
<img width="359" height="191" alt="image" src="https://github.com/user-attachments/assets/21b23e1a-599a-4f1e-8865-723972e90267" />

## After
<img width="363" height="206" alt="image" src="https://github.com/user-attachments/assets/8fcd1c12-0f65-447e-961e-a379c9fc250f" />
<img width="355" height="185" alt="image" src="https://github.com/user-attachments/assets/60af9154-7d52-458c-b50a-e0adaedf63d9" />
